### PR TITLE
Fix missing namespace declaration on ext level in __init__.py 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,10 @@
+3.3.6 (unreleased)
+------------------
+
+- Fix missing namespace declaration on ``ext``level in ``__init__.py`` and 
+  avoid recent setuptools to spit and fail.
+
+
 3.3.5 (2014/07/13)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ description_txt = open('README.txt').read()
 description_txt += '\n\nChanges\n-------\n\n'
 description_txt += open('CHANGES.txt').read()
 
-version = '3.3.5'
+version = '3.3.6'
 
 setup(name="zopyx.txng3.ext",
       version=version,

--- a/zopyx/txng3/ext/__init__.py
+++ b/zopyx/txng3/ext/__init__.py
@@ -1,1 +1,2 @@
 # placeholder
+__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
Avoid:

Getting distribution for 'zopyx.txng3.ext'.
error: Setup script exited with error: Namespace package problem: zopyx.txng3.ext is a namespace package, but its
**init**.py does not call declare_namespace()! Please fix it.
(See the setuptools manual under "Namespace Packages" for details.)
"
An error occurred when trying to install zopyx.txng3.ext 3.3.5. Look above this message for any errors that were output by easy_install.
While:
  Updating instance.
  Getting distribution for 'zopyx.txng3.ext'.
Error: Couldn't install: zopyx.txng3.ext 3.3.5
