### PR TITLE
PyPy support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,17 @@
 language:  python
+sudo: false
 
 python:
-  - "2.7"
+  - 2.6
+  - 2.7
   - pypy
 
-before_script:
-  - sudo apt-get install -qq pdftk
-  - sudo apt-get install -qq poppler-utils
+install:
+  - python bootstrap.py
+  - bin/buildout
 
-script: 
-  - bash build_test.sh python-$TRAVIS_PYTHON_VERSION
+script:
+  - bin/test-jenkins --xml
 
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language:  python
 
 python:
   - "2.7"
+  - pypy
 
 before_script:
   - sudo apt-get install -qq pdftk

--- a/zopyx/txng3/ext/normalizer_src/normalizer.c
+++ b/zopyx/txng3/ext/normalizer_src/normalizer.c
@@ -1,5 +1,5 @@
 /*
- TextIndexNG V 3                
+ TextIndexNG V 3
  The next generation TextIndex for Zope
 
  This software is governed by a license. See
@@ -83,7 +83,7 @@ static PyObject *normalize(Normalizer *self, PyObject *args)
 
         list = PyList_New(0);
 
-        data = PySequence_Fast(data, "object must be sequence"); 
+        data = PySequence_Fast(data, "object must be sequence");
 
         for (j=0; j<PyList_Size(data); j++) {
             PyObject *word=NULL,*item=NULL;
@@ -208,12 +208,12 @@ static PyTypeObject NormalizerType = {
 static char *Normalizer_args[]={"translation","encoding",NULL};
 
 void CopyTranslationTable(Normalizer *self, PyObject *table) {
-    
+
     int i;
 
     self->table = PyList_New(0);
 
-    table = PySequence_Fast(table, "argument must be sequence"); 
+    table = PySequence_Fast(table, "argument must be sequence");
 
     for (i=0; i<PyObject_Length(table); i++) {
         PyObject *item, *key, *value, *tp;
@@ -223,17 +223,17 @@ void CopyTranslationTable(Normalizer *self, PyObject *table) {
         key   = PyTuple_GetItem(item,0);
         value = PyTuple_GetItem(item,1);
 
-        if (PyString_Check(key))  
+        if (PyString_Check(key))
             key = PyUnicode_FromEncodedObject(key, self->encoding,"strict");
         else Py_XINCREF(key);
 
-        if (PyString_Check(value)) 
+        if (PyString_Check(value))
             value = PyUnicode_FromEncodedObject(value, self->encoding,"strict");
         else Py_XINCREF(value);
 
         tp = Py_BuildValue("(OO)",key,value);
         PyList_Append(self->table, tp);
-    
+
         Py_DECREF(tp);
         Py_DECREF(value);
         Py_DECREF(key);
@@ -269,9 +269,9 @@ newNormalizer(PyObject *modinfo, PyObject *args, PyObject *keywds)
 
 static struct PyMethodDef Normalizer_module_methods[] =
     {
-        { "Normalizer", (PyCFunction) newNormalizer, 
+        { "Normalizer", (PyCFunction) newNormalizer,
           METH_VARARGS|METH_KEYWORDS,
-          "Normalizer(list, [encoding='latin1')" 
+          "Normalizer(list, [encoding='latin1')"
           "-- Normalizer module - takes a list of 2-tuples of strings/unicode strings"
         },
         { NULL, NULL }
@@ -281,6 +281,11 @@ static struct PyMethodDef Normalizer_module_methods[] =
 void
 initnormalizer(void)
 {
+
+  if (PyType_Ready(&NormalizerType) < 0) {
+	  return;
+  }
+
     Py_InitModule3("normalizer", Normalizer_module_methods,
                    "TextIndexNG Normalizer module");
 }

--- a/zopyx/txng3/ext/splitter_src/splitter.c
+++ b/zopyx/txng3/ext/splitter_src/splitter.c
@@ -330,6 +330,12 @@ static PyTypeObject SplitterType = {
                                        (setattrfunc)0,                    /*tp_setattr*/
                                        (cmpfunc)0,                        /*tp_compare*/
                                        (reprfunc)0,                       /*tp_repr*/
+                                       0,                                 /*tp_as_number*/
+                                       &Splitter_as_sequence,         /*tp_as_sequence*/
+                                       0,                                 /*tp_as_mapping*/
+                                       (hashfunc)0,                       /*tp_hash*/
+                                       (ternaryfunc)0,                    /*tp_call*/
+                                       (reprfunc)0,                       /*tp_str*/
                                        /* Space for future expansion */
                                        0L,0L,0L,0L,
                                        SplitterType__doc__ /* Documentation string */

--- a/zopyx/txng3/ext/splitter_src/tests/testTXNGSplitter.py
+++ b/zopyx/txng3/ext/splitter_src/tests/testTXNGSplitter.py
@@ -1,7 +1,7 @@
 # -*- coding: iso-8859-1
 
 ###########################################################################
-# TextIndexNG V 3                
+# TextIndexNG V 3
 # The next generation TextIndex for Zope
 #
 # This software is governed by a license. See
@@ -23,7 +23,6 @@ class SplitterTests(unittest.TestCase):
         self.assertEqual(got, expected)
 
     def testSimple(self):
-
         SP = Splitter()
         self._test(SP, '',  [])
         self._test(SP, 'foo',  ['foo'])
@@ -32,6 +31,7 @@ class SplitterTests(unittest.TestCase):
         self._test(SP, ' foo bar', ['foo','bar'])
         self._test(SP, ' foo bar ', ['foo','bar'])
         self._test(SP, ' foo 23 25 bar ', ['foo','23','25','bar'])
+
 
     def testDisabledCaseFolding(self):
 
@@ -56,7 +56,7 @@ class SplitterTests(unittest.TestCase):
         self._test(SP, ' foo Bar ', ['foo','bar'])
 
     def testMaxlen(self):
-        
+
         SP = Splitter(maxlen=5)
         self._test(SP, 'abcdefg foo barfoo', ['abcde','foo','barfo'])
         self._test(SP, 'abcdefg'*2000, ['abcde'])
@@ -98,7 +98,7 @@ class SplitterTests(unittest.TestCase):
 
     def testParagraphs(self):
         SP = Splitter(singlechar=1, separator='§')
-        
+
         self._test(SP, 'dies ist §8 b b§b',
                        ['dies', 'ist', '§8', 'b', 'b§b'])
 
@@ -129,10 +129,9 @@ def debug():
 def pdebug():
     import pdb
     pdb.run('debug()')
-   
+
 if __name__=='__main__':
    if len(sys.argv) > 1:
       globals()[sys.argv[1]]()
    else:
       main()
-

--- a/zopyx/txng3/ext/stemmer_src/stemmer.c
+++ b/zopyx/txng3/ext/stemmer_src/stemmer.c
@@ -61,7 +61,8 @@ Stemmer_stem (Stemmer * self, PyObject * args)
   PyObject *obj, *list, *item, *encoded, *u_stemmed;
   const sb_symbol *stemmed;
   char *word;
-  int i;
+  Py_ssize_t i;
+  Py_ssize_t len;
 
   if (self == NULL)
 	  {
@@ -85,9 +86,10 @@ Stemmer_stem (Stemmer * self, PyObject * args)
      return NULL;
    }
 
-  list = PyList_New (0);
+  len = PySequence_Length (obj);
+  list = PyList_New (len);
 
-  for (i = 0; i < PyObject_Length (obj); i++)
+  for (i = 0; i < len; i++)
 	  {
 
 		item = PySequence_Fast_GET_ITEM (obj, i);
@@ -100,7 +102,7 @@ Stemmer_stem (Stemmer * self, PyObject * args)
 				PyUnicode_AsEncodedString (item, "UTF-8", "ignore");
 
 			  // -> byte string
-			  word = PyString_AsString (encoded);
+			  word = PyString_AS_STRING (encoded);
 
 			  // now stem
 			  stemmed =
@@ -114,8 +116,7 @@ Stemmer_stem (Stemmer * self, PyObject * args)
 									  sb_stemmer_length (self->stemmer),
 									  "ignore");
 
-			  PyList_Append (list, u_stemmed);
-			  Py_DECREF (u_stemmed);
+			  PyList_SET_ITEM(list, i, u_stemmed); // steals the reference
 			}
 		else
 			{
@@ -141,12 +142,6 @@ static struct PyMethodDef Stemmer_methods[] = {
 };
 
 
-static PyObject *
-Stemmer_getattr (Stemmer * self, char *name)
-{
-  return Py_FindMethod (Stemmer_methods, (PyObject *) self, name);
-}
-
 static char StemmerType__doc__[] = "Stemmer object";
 
 static PyTypeObject StemmerType = {
@@ -157,7 +152,7 @@ static PyTypeObject StemmerType = {
   /* methods */
   (destructor) Stemmer_dealloc,	/*tp_dealloc */
   (printfunc) 0,				/*tp_print */
-  (getattrfunc) Stemmer_getattr,	/*tp_getattr */
+  (getattrfunc) 0,	/*tp_getattr */
   (setattrfunc) 0,				/*tp_setattr */
   (cmpfunc) 0,					/*tp_compare */
   (reprfunc) 0,					/*tp_repr */
@@ -170,7 +165,14 @@ static PyTypeObject StemmerType = {
 
   /* Space for future expansion */
   0L, 0L, 0L, 0L,
-  StemmerType__doc__			/* Documentation string */
+  StemmerType__doc__,			/* Documentation string */
+  /* tp_traverse       */ (traverseproc)0,
+  /* tp_clear          */ (inquiry)0,
+  /* tp_richcompare    */ (richcmpfunc)0,
+  /* tp_weaklistoffset */ (long)0,
+  (getiterfunc)0,		/*tp_iter*/
+  /* tp_iternext       */ (iternextfunc)0,
+  /* tp_methods        */ Stemmer_methods,
 };
 
 

--- a/zopyx/txng3/ext/stemmer_src/stemmer.c
+++ b/zopyx/txng3/ext/stemmer_src/stemmer.c
@@ -1,5 +1,5 @@
 /*
- TextIndexNG V 3                
+ TextIndexNG V 3
  The next generation TextIndex for Zope
 
  This software is governed by a license. See
@@ -45,8 +45,8 @@ static PyObject *Stemmer_availableStemmers(Stemmer *self,PyObject*args)
           PyList_Append(list, lang);
           Py_DECREF(lang);
           i++;
-      }           
-      else 
+      }
+      else
         break;
     }
     PyList_Sort(list);
@@ -217,6 +217,10 @@ initstemmer (void)
 {
   PyObject *m;
   char rev[] = "$Revision: 2373 $";
+
+  if (PyType_Ready(&StemmerType) < 0) {
+	  return;
+  }
 
   /* Create the module and add the functions */
   m = Py_InitModule3 ("stemmer", stemmer_module_methods,


### PR DESCRIPTION
This consists of two minor changes. First, use the `PyUnicode` accessors instead of accessing `->str` and `->length` directly (on CPython, these are macros that do exactly that so there's no speed penalty, but the internal layout of the objects is different under PyPy) . Second, make sure and complete the construction of the extension types using `PyType_Ready` when the module is initialized (this is technically required for both implementations, but CPython got away without it, whereas PyPy crashes).

All existing tests run and pass under PyPy 2.5.1 and 2.6alpha with these changes (albeit a bit slowly, about 30s versus 9s in CPython2.7.9.)