### PR TITLE
Support Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 /dist
 /build
 /bin
+.installed.cfg
+develop-eggs/
+eggs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - pypy
+  - pypy-5.4.1
 
 install:
   - python bootstrap.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ sudo: false
 
 python:
   - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
   - pypy
 
 install:
@@ -10,7 +13,7 @@ install:
   - bin/buildout
 
 script:
-  - bin/test 
+  - bin/test
 
 
 notifications:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+4.0.0 (unreleased)
+------------------
+- Added support for Python 3.4, 3.5 and 3.6.
+
 3.4.0 (2016/02/02)
 ------------------
 - added support for PyPy
@@ -6,7 +10,7 @@
 3.3.7 (2014/09/05)
 ------------------
 
-- Fix missing namespace declaration on ``ext``level in ``__init__.py`` and 
+- Fix missing namespace declaration on ``ext``level in ``__init__.py`` and
   avoid recent setuptools to spit and fail.
 
 3.3.5 (2014/07/13)
@@ -20,7 +24,7 @@
 
 3.3.3 (2012/05/16)
 ------------------
-- applied patch for 
+- applied patch for
   https://sourceforge.net/tracker/?func=detail&atid=458418&aid=3527329&group_id=50052
 
 3.3.2 (2010/03/10)
@@ -34,4 +38,3 @@
 3.3.0 (2009/03/15)
 ------------------
 - refactored and re-released as zopyx.txng3.ext
-

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 ###########################################################################
-# TextIndexNG V 3                
+# TextIndexNG V 3
 # The next generation TextIndex for Zope
 #
 # This software is governed by a license. See
@@ -13,8 +13,8 @@ import sys
 import os
 from setuptools import setup, find_packages, Extension
 
-unicode_arg = sys.maxunicode>0xffff and "-DUNICODE_WIDTH=4" or "-DUNICODE_WIDTH=2" 
-ext_args = sys.platform != "win32" and ['-Wall'] or [] 
+unicode_arg = sys.maxunicode>0xffff and "-DUNICODE_WIDTH=4" or "-DUNICODE_WIDTH=2"
+ext_args = sys.platform != "win32" and ['-Wall'] or []
 
 description_txt = open('README.txt').read()
 description_txt += '\n\nChanges\n-------\n\n'
@@ -31,6 +31,18 @@ setup(name="zopyx.txng3.ext",
       zip_safe=False,
       description = 'Helper modules for TextIndexNG3 (Snowball stemmer, normalizer, splitter, etc.)',
       long_description = description_txt,
+      classifiers = [
+          'Intended Audience :: Developers',
+          'Programming Language :: Python',
+          'Programming Language :: Python :: 2',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: Implementation :: CPython',
+          'Programming Language :: Python :: Implementation :: PyPy',
+          'Operating System :: OS Independent',
+      ],
       url = "http://sf.net/projects/textindexng/",
       py_modules=['zopyx.__init__', 'zopyx.txng3.__init__', 'zopyx.txng3.ext.__init__'],
       install_requires=('setuptools',),
@@ -47,7 +59,7 @@ setup(name="zopyx.txng3.ext",
             Extension("zopyx.txng3.ext.splitter",
                 [ "zopyx/txng3/ext/splitter_src/splitter.c",
                   "zopyx/txng3/ext/splitter_src/hashtable.c",
-                  "zopyx/txng3/ext/splitter_src/dict.c" 
+                  "zopyx/txng3/ext/splitter_src/dict.c"
                 ],
             ),
 
@@ -97,10 +109,9 @@ setup(name="zopyx.txng3.ext",
                  "zopyx/txng3/ext/stemmer_src/libstemmer_c/src_c/stem_UTF_8_swedish.c",
                  "zopyx/txng3/ext/stemmer_src/libstemmer_c/src_c/stem_UTF_8_turkish.c",
                 ],
-                include_dirs=['zopyx/txng3/ext/stemmer_src/libstemmer_c/include', 
+                include_dirs=['zopyx/txng3/ext/stemmer_src/libstemmer_c/include',
                               'zopyx/txng3/ext/stemmer_src/libstemmer_c',
                               'zopyx/txng3/ext/stemmer_src/libstemmer_c/libstemmer'],
             ),
         ]
     )
-

--- a/zopyx/txng3/ext/normalizer_src/tests/testNormalizer.py
+++ b/zopyx/txng3/ext/normalizer_src/tests/testNormalizer.py
@@ -1,7 +1,7 @@
 #-*- coding: iso-8859-15 -*-
 
 ###########################################################################
-# TextIndexNG V 3                
+# TextIndexNG V 3
 # The next generation TextIndex for Zope
 #
 # This software is governed by a license. See
@@ -28,7 +28,7 @@ class TestNormalizer(unittest.TestCase):
         self.assertEqual(got, expected)
 
     def testSimple(self):
-        
+
         N = Normalizer( [] )
         self.assertEqual(N.getTable(), [] )
 
@@ -46,7 +46,7 @@ class TestNormalizer(unittest.TestCase):
         table = [ ('a','bb'), ('bb','cc') ]
         text = 'the quick brown fox jumps over the lazy dog'
         self._doTest(text, table)
-            
+
     def test3(self):
 
         table = [ ('foo','bar') ]
@@ -63,8 +63,8 @@ class TestNormalizer(unittest.TestCase):
     def test5(self):
 
         table = [ (u'Ä',u'Ae'), (u'Ö',u'Oe') ]
-        text = unicode('Bei den dreitägigen Angriffen seien auch bis'\
-               'auf einen alle Flugplätze der Taliban zerstört worden','latin1')
+        text = (u'Bei den dreitägigen Angriffen seien auch bis'
+                u'auf einen alle Flugplätze der Taliban zerstört worden')
         self._doTest(text, table)
 
 
@@ -82,10 +82,9 @@ def debug():
 def pdebug():
     import pdb
     pdb.run('debug()')
-   
+
 if __name__=='__main__':
    if len(sys.argv) > 1:
       globals()[sys.argv[1]]()
    else:
       main()
-

--- a/zopyx/txng3/ext/splitter_src/tests/testTXNGSplitter.py
+++ b/zopyx/txng3/ext/splitter_src/tests/testTXNGSplitter.py
@@ -12,6 +12,14 @@
 import unittest, sys
 from zopyx.txng3.ext.splitter import Splitter
 
+try:
+    unicode
+except NameError:
+    def unicode(x, enc):
+        if isinstance(x, str):
+            return x
+        return x.decode(enc)
+
 class SplitterTests(unittest.TestCase):
 
     encoding = 'iso-8859-15'
@@ -19,7 +27,8 @@ class SplitterTests(unittest.TestCase):
     def _test(self, SP, text, expected):
 
         got = SP.split(text, self.encoding)
-        expected = [ unicode(x, self.encoding) for x in expected ]
+        expected = [ unicode(x, self.encoding) if isinstance(x, bytes) else x
+                     for x in expected ]
         self.assertEqual(got, expected)
 
     def testSimple(self):
@@ -100,13 +109,14 @@ class SplitterTests(unittest.TestCase):
         SP = Splitter(singlechar=1, separator='§')
 
         self._test(SP, 'dies ist §8 b b§b',
-                       ['dies', 'ist', '§8', 'b', 'b§b'])
+                       [u'dies', u'ist', u'§8', u'b', u'b§b'])
 
     def testSingleCharCachePoisoning(self):
         SP = Splitter()
 
         SP.split(u'D')
-        self.assertEqual(u'D', unicode('D'))
+        if str is bytes:
+            self.assertEqual(u'D', unicode('D'))
 
     def testSingleCharComparisonPoisoning(self):
         SP = Splitter()

--- a/zopyx/txng3/ext/stemmer_src/tests/testStemmer.py
+++ b/zopyx/txng3/ext/stemmer_src/tests/testStemmer.py
@@ -1,5 +1,5 @@
 ###########################################################################
-# TextIndexNG V 3                
+# TextIndexNG V 3
 # The next generation TextIndex for Zope
 #
 # This software is governed by a license. See
@@ -13,6 +13,12 @@ from zopyx.txng3.ext.stemmer import Stemmer
 
 __basedir__ = os.path.dirname(__file__)
 
+try:
+    unicode
+except NameError:
+    def unicode(x, enc):
+        return x.decode(enc)
+
 class SimpleStemmerTests(unittest.TestCase):
 
     def getData(self, lang):
@@ -20,8 +26,8 @@ class SimpleStemmerTests(unittest.TestCase):
         voc = gzip.open(os.path.join(__basedir__, lang, 'voc.txt.gz')).read()
         out = gzip.open(os.path.join(__basedir__, lang, 'output.txt.gz')).read()
 
-        voc = [ x.strip() for x in voc.split('\n') ]
-        out = [ x.strip() for x in out.split('\n') ]
+        voc = [ x.strip() for x in voc.split(b'\n') ]
+        out = [ x.strip() for x in out.split(b'\n') ]
 
         assert len(voc) == len(out)
         return voc, out
@@ -117,10 +123,9 @@ def debug():
 def pdebug():
     import pdb
     pdb.run('debug()')
-   
+
 if __name__=='__main__':
    if len(sys.argv) > 1:
       globals()[sys.argv[1]]()
    else:
       main()
-

--- a/zopyx/txng3/ext/support.c
+++ b/zopyx/txng3/ext/support.c
@@ -1,5 +1,5 @@
 /*
- TextIndexNG V 3                
+ TextIndexNG V 3
  The next generation TextIndex for Zope
 
  This software is governed by a license. See
@@ -8,7 +8,9 @@
 
 #include "Python.h"
 #include <stdlib.h>
-
+#if PY_MAJOR_VERSION >= 3
+#define PY3K
+#endif
 
 static PyObject *
 stopwordfilter(PyObject *modinfo, PyObject *args)
@@ -45,22 +47,44 @@ static struct PyMethodDef support_module_methods[] =
         { NULL, NULL }
     };
 
+#ifdef PY3K
+static struct PyModuleDef moduledef = {
+        PyModuleDef_HEAD_INIT,
+        "support",                      /* m_name */
+        "TexnIndexNG support module",   /* m_doc */
+        -1,                             /* m_size */
+        support_module_methods,         /* m_methods */
+        NULL,                           /* m_reload */
+        NULL,                           /* m_traverse */
+        NULL,                           /* m_clear */
+        NULL,                           /* m_free */
+    };
+#endif
 
-void
-initsupport(void)
+static PyObject*
+module_init(void)
 {
-    PyObject *m, *d;
-    char *rev="$Revision: 2068 $";
+    PyObject *m;
 
     /* Create the module and add the functions */
+#ifdef PY3K
+    m = PyModule_Create(&moduledef);
+#else
     m = Py_InitModule3("support", support_module_methods,
-                        "TextIndexNG support module"); 
-
-    /* Add some symbolic constants to the module */
-    d = PyModule_GetDict(m);
-    PyDict_SetItemString(d, "__version__",
-                         PyString_FromStringAndSize(rev+11,strlen(rev+11)-2));
-    if (PyErr_Occurred())
-        Py_FatalError("can't initialize module support");
+                        "TextIndexNG support module");
+#endif
+    return m;
 }
 
+
+#ifdef PY3K
+PyMODINIT_FUNC PyInit_support(void)
+{
+    return module_init();
+}
+#else
+PyMODINIT_FUNC initsupport(void)
+{
+    module_init();
+}
+#endif


### PR DESCRIPTION
- A pretty mechanical transformation: lots of PyString -> PyBytes, which are aliases for each other on Python 2, a few PyInt -> PyLong macros, etc.
- Tested locally with Python 3.5 and all tests pass. (They all pass on Travis too, for all versions.)
- There's minimal test modifications. 
- The 'levenshtein' module doesn't seem to have much in the way of tests so I'm not 100% confident in it, but it compiles without warnings. (Well, without new warnings, AFAICS.)
- I removed the `__version__` strings that were being set in a couple of the modules because it avoided dealing with some Python 2 vs Python 3 issues, and because they appear to be hardcoded and not updated anymore as they were Subversion metadata.

This is enough to get zc.catalog, at least, to pass its tests.